### PR TITLE
explicitly build sptps_speed [Done]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ PKG_VERSION:=1.1-pre15
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/excogitation/tinc.git
+PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=fbf2b70435e01cf9a14e34c6f80f44fbe4107f1d
+PKG_SOURCE_VERSION:=af81c436d6e11a53803747af7cc8ecfd449ccd4c
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_MIRROR_MD5SUM:=
 
@@ -49,9 +49,9 @@ CONFIGURE_ARGS += \
 
 define Package/tinc/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/sptps_speed $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tinc $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tincd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/sptps_speed $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)
 	$(INSTALL_DIR) $(1)/etc/config
@@ -60,6 +60,13 @@ define Package/tinc/install
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_DATA) files/tinc.upgrade $(1)/lib/upgrade/keep.d/tinc
 endef
+
+MAKE_PATH:=src
+define Build/Compile
+	$(call Build/Compile/Default)
+	$(call Build/Compile/Default,sptps_speed)
+endef
+
 
 define Package/tinc/conffiles
 /etc/config/tinc


### PR DESCRIPTION
uses openWRT `Build/Compile` instead of a different fork

Hash needs to be changed to upstream, needs to be re-tested